### PR TITLE
vendor: Keep qcom components conditionally

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -205,7 +205,7 @@ PRODUCT_PRODUCT_PROPERTIES += \
 -include vendor/lineage/config/partner_gms.mk
 
 # QTI Perf
-ifeq ($(BOARD_USES_QCOM_HARDWARE),)
+ifeq ($(TARGET_QCOM_COMPONENTS),true)
 -include vendor/qcom/common/perf/perf-vendor.mk
 TARGET_COMMON_QTI_COMPONENTS := perf
 


### PR DESCRIPTION
* This causes qti perf to stop being called automatically, causing errors in the logs.

Change-Id: Ie37d3d6a59dfb3d3e41603f85f8d354c3b9d9104